### PR TITLE
fix: remove the option to override the default tab output delimiter

### DIFF
--- a/ngsderive/__main__.py
+++ b/ngsderive/__main__.py
@@ -44,9 +44,6 @@ def get_args():
         default="stdout",
     )
     common.add_argument(
-        "--delimiter", default="<tab>", help="Delimiter for the outfile."
-    )
-    common.add_argument(
         "--debug", default=False, action="store_true", help="Enable DEBUG log level."
     )
     common.add_argument(
@@ -264,10 +261,6 @@ def process_args(args):
     else:
         args.outfile = open(args.outfile, "w")
 
-    # set delimiter
-    if args.delimiter == "<tab>":
-        args.delimiter = "\t"
-
 
 def run():
     args = get_args()
@@ -277,7 +270,6 @@ def run():
         readlen.main(
             args.ngsfiles,
             outfile=args.outfile,
-            delimiter=args.delimiter,
             n_samples=args.n_samples,
             majority_vote_cutoff=args.majority_vote_cutoff,
         )
@@ -285,7 +277,6 @@ def run():
         instrument.main(
             args.ngsfiles,
             outfile=args.outfile,
-            delimiter=args.delimiter,
             n_samples=args.n_samples,
         )
     if args.subcommand == "strandedness":
@@ -293,7 +284,6 @@ def run():
             args.ngsfiles,
             args.gene_model,
             outfile=args.outfile,
-            delimiter=args.delimiter,
             n_genes=args.n_genes,
             minimum_reads_per_gene=args.minimum_reads_per_gene,
             only_protein_coding_genes=args.only_protein_coding_genes,
@@ -305,7 +295,6 @@ def run():
         encoding.main(
             args.ngsfiles,
             outfile=args.outfile,
-            delimiter=args.delimiter,
             n_samples=args.n_samples,
         )
     if args.subcommand == "junction-annotation":
@@ -313,7 +302,6 @@ def run():
             args.ngsfiles,
             args.gene_model,
             outfile=args.outfile,
-            delimiter=args.delimiter,
             min_intron=args.min_intron,
             min_mapq=args.min_mapq,
             min_reads=args.min_reads,

--- a/ngsderive/commands/encoding.py
+++ b/ngsderive/commands/encoding.py
@@ -17,12 +17,12 @@ ILLUMINA_1_0_SET = set([i for i in range(26, 93)])
 ILLUMINA_1_3_SET = set([i for i in range(31, 93)])
 
 
-def main(ngsfiles, outfile=sys.stdout, delimiter="\t", n_samples=1000000):
+def main(ngsfiles, outfile=sys.stdout, n_samples=1000000):
 
     writer = csv.DictWriter(
         outfile,
         fieldnames=["File", "Evidence", "ProbableEncoding"],
-        delimiter=delimiter,
+        delimiter="\t",
     )
     writer.writeheader()
     outfile.flush()

--- a/ngsderive/commands/instrument.py
+++ b/ngsderive/commands/instrument.py
@@ -184,11 +184,11 @@ def resolve_instrument(
         )
 
 
-def main(ngsfiles, outfile=sys.stdout, delimiter="\t", n_samples=10000):
+def main(ngsfiles, outfile=sys.stdout, n_samples=10000):
     writer = csv.DictWriter(
         outfile,
         fieldnames=["File", "Instrument", "Confidence", "Basis"],
-        delimiter=delimiter,
+        delimiter="\t",
     )
     writer.writeheader()
     outfile.flush()

--- a/ngsderive/commands/junction_annotation.py
+++ b/ngsderive/commands/junction_annotation.py
@@ -251,7 +251,6 @@ def main(
     ngsfiles,
     gene_model_file,
     outfile=sys.stdout,
-    delimiter="\t",
     min_intron=50,
     min_mapq=30,
     min_reads=1,
@@ -287,7 +286,7 @@ def main(
         "complete_novel_spliced_reads",
     ]
 
-    writer = csv.DictWriter(outfile, fieldnames=fieldnames, delimiter=delimiter)
+    writer = csv.DictWriter(outfile, fieldnames=fieldnames, delimiter="\t")
     writer.writeheader()
     outfile.flush()
 

--- a/ngsderive/commands/readlen.py
+++ b/ngsderive/commands/readlen.py
@@ -13,7 +13,6 @@ logger = logging.getLogger("readlen")
 def main(
     ngsfiles,
     outfile=sys.stdout,
-    delimiter="\t",
     n_samples=100000,
     majority_vote_cutoff=0.7,
 ):
@@ -21,7 +20,7 @@ def main(
     writer = csv.DictWriter(
         outfile,
         fieldnames=["File", "Evidence", "MajorityPctDetected", "ConsensusReadLength"],
-        delimiter=delimiter,
+        delimiter="\t",
     )
     writer.writeheader()
     outfile.flush()

--- a/ngsderive/commands/strandedness.py
+++ b/ngsderive/commands/strandedness.py
@@ -288,7 +288,6 @@ def main(
     ngsfiles,
     gene_model_file,
     outfile=sys.stdout,
-    delimiter="\t",
     n_genes=100,
     minimum_reads_per_gene=10,
     only_protein_coding_genes=True,
@@ -329,7 +328,7 @@ def main(
         fieldnames = ["ReadGroup"] + fieldnames
     fieldnames = ["File"] + fieldnames
 
-    writer = csv.DictWriter(outfile, fieldnames=fieldnames, delimiter=delimiter)
+    writer = csv.DictWriter(outfile, fieldnames=fieldnames, delimiter="\t")
     writer.writeheader()
     outfile.flush()
 


### PR DESCRIPTION
BREAKING CHANGE: This removes the `--delimiter` commandline arg

As discussed in a MultiQC PR, https://github.com/ewels/MultiQC/pull/1370, the optional override required us to search a regex when looking for `ngsderive` files. This presented a major slowdown in MultiQC when searching through massive minified JSONs. IMO any value provided by this optional override isn't worth deviating from the best practice of having consistently formatted output files.

The maintainer of MultiQC wrote this persuasive blog post on the topic: http://tallphil.co.uk/writing-good-log-files/ 