### PR TITLE
BREAKING CHANGE(junction-annotation): by default discard unannotated contigs

### DIFF
--- a/docs/subcommands/encoding.md
+++ b/docs/subcommands/encoding.md
@@ -4,7 +4,7 @@ The `encoding` subcommand detects the likely PHRED score encoding schema used fo
 
 As a hypothetical example of a mis-translation; a FASTQ sequenced by an Illumina1.3 machine has PHRED quality scores ranging from 6-22. They would be encoded as ASCII values 70-86. If those ASCII values are not adjusted during BAM alignment, someone decoding the PHRED score according to the PHRED+33 specification would think the quality range for that sample was 37-53. This is erroneously high, and may convey undue confidence in the quality of the BAM.
 
-`ngsderive`'s encoding check implementation is based on details of the encoding schemes described [here][https://en.wikipedia.org/wiki/FASTQ_format#Encoding].
+`ngsderive`'s encoding check implementation is based on details of the encoding schemes described [here](https://en.wikipedia.org/wiki/FASTQ_format#Encoding).
 
 ## Limitations
 

--- a/docs/subcommands/junction_annotation.md
+++ b/docs/subcommands/junction_annotation.md
@@ -6,9 +6,10 @@ The following criteria are adjustable for junction detection and read filtering:
 
 | Option                               | Help                                                                                                  |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| `-i`, `--min-intron`                 | Minimum intron length to be considered a junction (default: `50`)                                     |
-| `-q`, `--min-mapq`                   | Minimum read quality to be considered a supporting read (default: `30`)                               |
-| `-m`, `--min-reads`                  | Minimum number of reads supporting a junction for it to be reported (default: `2`)                    |
-| `-k`, `--fuzzy-junction-match-range` | Consider exonic starts/ends within `+-k` bases of a known intron start/end to be known (default: `0`) |
+| `-i`, `--min-intron`                            | Minimum intron length to be considered a junction (default: `50`)                                     |
+| `-q`, `--min-mapq`                              | Minimum read quality to be considered a supporting read (default: `30`)                               |
+| `-m`, `--min-reads`                             | Minimum number of reads supporting a junction for it to be reported (default: `2`)                    |
+| `-k`, `--fuzzy-junction-match-range`            | Consider exonic starts/ends within `+-k` bases of a known intron start/end to be known (default: `0`) |
+| `-c`, `--consider-unannotated-references-novel` | For the summary report, consider all events on unannotated reference sequences `complete_novel`. Default is to exclude them from the summary. Either way, they will be annotated as `unannotated_reference` in the junctions file. (default: False) |
 
-In the resulting `<basename>.junctions.tsv` files, note that the coordinates are 0-based, end-exclusive. Generation of these files can be disabled with `--disable-junction-files`. Instead only the summary file of junction and splice counts will be generated.
+In the resulting `<basename>.junctions.tsv` files, note that the coordinates are 0-based, end-exclusive. Generation of these files can be disabled with `--disable-junction-files`. Instead only the summary of junction and splice counts will be generated.

--- a/ngsderive/__main__.py
+++ b/ngsderive/__main__.py
@@ -94,8 +94,8 @@ def get_args():
         "--max-tries",
         type=int,
         default=3,
-        help="When inconclusive, the test will repeat until this many tries have been reached. \
-            Evidence of previous attempts is saved and reused, leading to a larger sample size with multiple attempts.",
+        help="When inconclusive, the test will repeat until this many tries have been reached. "
+            "Evidence of previous attempts is saved and reused, leading to a larger sample size with multiple attempts.",
     )
     strandedness.add_argument(
         "--max-iterations-per-try",
@@ -202,10 +202,12 @@ def get_args():
         default=0,
     )
     junction_annotation.add_argument(
-        "-u",
-        "--discard-unannotated-contigs",
+        "-c",
+        "--consider-unannotated-references-novel",
         action="store_true",
-        help="Discard junctions which occur on an unannotated contig. Default considers them `complete_novel`.",
+        help="For the summary report, consider all events on unannotated reference sequences `complete_novel`. "
+            "Default is to exclude them from the summary. "
+            "Either way, they will be annotated as `unannotated_reference` in the junctions file.",
     )
 
     args = parser.parse_args()
@@ -316,7 +318,7 @@ def run():
             min_mapq=args.min_mapq,
             min_reads=args.min_reads,
             fuzzy_range=args.fuzzy_junction_match_range,
-            discard_unannotated_contigs=args.discard_unannotated_contigs,
+            consider_unannotated_references_novel=args.consider_unannotated_references_novel,
             junction_dir=args.junction_files_dir,
             disable_junction_files=args.disable_junction_files,
         )

--- a/ngsderive/__main__.py
+++ b/ngsderive/__main__.py
@@ -201,6 +201,12 @@ def get_args():
         help="Consider found splices within `+-k` bases of a known splice event annotated.",
         default=0,
     )
+    junction_annotation.add_argument(
+        "-u",
+        "--discard-unannotated-contigs",
+        action="store_true",
+        help="Discard junctions which occur on an unannotated contig. Default considers them `complete_novel`.",
+    )
 
     args = parser.parse_args()
     if not args.subcommand:
@@ -310,6 +316,7 @@ def run():
             min_mapq=args.min_mapq,
             min_reads=args.min_reads,
             fuzzy_range=args.fuzzy_junction_match_range,
+            discard_unannotated_contigs=args.discard_unannotated_contigs,
             junction_dir=args.junction_files_dir,
             disable_junction_files=args.disable_junction_files,
         )

--- a/ngsderive/__main__.py
+++ b/ngsderive/__main__.py
@@ -95,7 +95,7 @@ def get_args():
         type=int,
         default=3,
         help="When inconclusive, the test will repeat until this many tries have been reached. "
-            "Evidence of previous attempts is saved and reused, leading to a larger sample size with multiple attempts.",
+             "Evidence of previous attempts is saved and reused, leading to a larger sample size with multiple attempts.",
     )
     strandedness.add_argument(
         "--max-iterations-per-try",
@@ -206,8 +206,8 @@ def get_args():
         "--consider-unannotated-references-novel",
         action="store_true",
         help="For the summary report, consider all events on unannotated reference sequences `complete_novel`. "
-            "Default is to exclude them from the summary. "
-            "Either way, they will be annotated as `unannotated_reference` in the junctions file.",
+             "Default is to exclude them from the summary. "
+             "Either way, they will be annotated as `unannotated_reference` in the junctions file.",
     )
 
     args = parser.parse_args()

--- a/ngsderive/__main__.py
+++ b/ngsderive/__main__.py
@@ -205,6 +205,7 @@ def get_args():
         "-c",
         "--consider-unannotated-references-novel",
         action="store_true",
+        default=False,
         help="For the summary report, consider all events on unannotated reference sequences `complete_novel`. "
              "Default is to exclude them from the summary. "
              "Either way, they will be annotated as `unannotated_reference` in the junctions file.",

--- a/ngsderive/commands/junction_annotation.py
+++ b/ngsderive/commands/junction_annotation.py
@@ -30,7 +30,7 @@ def annotate_junctions(
     min_mapq,
     min_reads,
     fuzzy_range,
-    discard_unannotated_contigs,
+    consider_unannotated_references_novel,
     junction_dir,
     disable_junction_files,
 ):
@@ -98,17 +98,19 @@ def annotate_junctions(
         )
 
         if contig not in cache.exon_starts:
-            if discard_unannotated_contigs:
-                logger.info(f"{contig} not found in GFF. All events discarded.")
-                continue
-            logger.info(f"{contig} not found in GFF. All events novel.")
-            annotation = "complete_novel"
+            logger.info(f"{contig} not found in GFF. All events marked `unannotated_reference`.")
+            annotation = "unannotated_reference"
+            if consider_unannotated_references_novel:
+                logger.info(f"Events being considered novel for summary report.")
+
             for intron_start, intron_end, num_reads in events:
                 if num_reads < min_reads:
                     num_too_few_reads += 1
                     continue
-                num_novel += 1
-                num_novel_spliced_reads += num_reads
+                if consider_unannotated_references_novel:
+                    num_novel += 1
+                    num_novel_spliced_reads += num_reads
+
                 if junction_file:
                     print(
                         "\t".join(
@@ -259,7 +261,7 @@ def main(
     min_mapq=30,
     min_reads=1,
     fuzzy_range=0,
-    discard_unannotated_contigs=False,
+    consider_unannotated_references_novel=False,
     junction_dir="./",
     disable_junction_files=False,
 ):
@@ -269,7 +271,7 @@ def main(
     logger.info("  - Minimum MAPQ: {}".format(min_mapq))
     logger.info("  - Minimum reads per junction: {}".format(min_reads))
     logger.info("  - Fuzzy junction range: +-{}".format(fuzzy_range))
-    logger.info("  - Discard unannotated contigs: {}".format(discard_unannotated_contigs))
+    logger.info("  - Consider unannotated references novel: {}".format(consider_unannotated_references_novel))
 
     logger.debug("Processing gene model...")
     gff = GFF(
@@ -308,7 +310,7 @@ def main(
             min_mapq=min_mapq,
             min_reads=min_reads,
             fuzzy_range=fuzzy_range,
-            discard_unannotated_contigs=discard_unannotated_contigs,
+            consider_unannotated_references_novel=consider_unannotated_references_novel,
             junction_dir=junction_dir,
             disable_junction_files=disable_junction_files,
         )

--- a/ngsderive/commands/junction_annotation.py
+++ b/ngsderive/commands/junction_annotation.py
@@ -30,6 +30,7 @@ def annotate_junctions(
     min_mapq,
     min_reads,
     fuzzy_range,
+    discard_unannotated_contigs,
     junction_dir,
     disable_junction_files,
 ):
@@ -97,6 +98,9 @@ def annotate_junctions(
         )
 
         if contig not in cache.exon_starts:
+            if discard_unannotated_contigs:
+                logger.info(f"{contig} not found in GFF. All events discarded.")
+                continue
             logger.info(f"{contig} not found in GFF. All events novel.")
             annotation = "complete_novel"
             for intron_start, intron_end, num_reads in events:
@@ -255,6 +259,7 @@ def main(
     min_mapq=30,
     min_reads=1,
     fuzzy_range=0,
+    discard_unannotated_contigs=False,
     junction_dir="./",
     disable_junction_files=False,
 ):
@@ -264,6 +269,7 @@ def main(
     logger.info("  - Minimum MAPQ: {}".format(min_mapq))
     logger.info("  - Minimum reads per junction: {}".format(min_reads))
     logger.info("  - Fuzzy junction range: +-{}".format(fuzzy_range))
+    logger.info("  - Discard unannotated contigs: {}".format(discard_unannotated_contigs))
 
     logger.debug("Processing gene model...")
     gff = GFF(
@@ -302,6 +308,7 @@ def main(
             min_mapq=min_mapq,
             min_reads=min_reads,
             fuzzy_range=fuzzy_range,
+            discard_unannotated_contigs=discard_unannotated_contigs,
             junction_dir=junction_dir,
             disable_junction_files=disable_junction_files,
         )

--- a/ngsderive/commands/junction_annotation.py
+++ b/ngsderive/commands/junction_annotation.py
@@ -259,7 +259,7 @@ def main(
     outfile=sys.stdout,
     min_intron=50,
     min_mapq=30,
-    min_reads=1,
+    min_reads=2,
     fuzzy_range=0,
     consider_unannotated_references_novel=False,
     junction_dir="./",

--- a/ngsderive/commands/strandedness.py
+++ b/ngsderive/commands/strandedness.py
@@ -335,9 +335,7 @@ def main(
         fieldnames = ["ReadGroup"] + fieldnames
     fieldnames = ["File"] + fieldnames
 
-    writer = csv.DictWriter(outfile, fieldnames=fieldnames, delimiter="\t")
-    writer.writeheader()
-    outfile.flush()
+    writer = None
 
     for ngsfilepath in ngsfiles:
         tries_for_file = 0
@@ -369,6 +367,9 @@ def main(
             if entries_contains_inconclusive and tries_for_file < max_tries:
                 continue
 
+            if not writer:
+                writer = csv.DictWriter(outfile, fieldnames=fieldnames, delimiter="\t")
+                writer.writeheader()
             for entry in entries:
                 writer.writerow(entry)
                 outfile.flush()

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,10 +48,7 @@ mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
 tomli = ">=0.2.6,<2.0.0"
-typing-extensions = [
-    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
-    {version = ">=3.10.0.0,<3.10.0.1 || >3.10.0.1", markers = "python_version >= \"3.10\""},
-]
+typing-extensions = ">=3.10.0.0"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -431,14 +428,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.30"
-description = "GitPython is a python library used to interact with Git repositories"
+version = "3.1.31"
+description = "GitPython is a Python library used to interact with Git repositories"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "GitPython-3.1.30-py3-none-any.whl", hash = "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"},
-    {file = "GitPython-3.1.30.tar.gz", hash = "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8"},
+    {file = "GitPython-3.1.31-py3-none-any.whl", hash = "sha256:f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d"},
+    {file = "GitPython-3.1.31.tar.gz", hash = "sha256:8ce3bcf69adfdf7c7d503e78fd3b1c492af782d58893b650adb2ac8912ddd573"},
 ]
 
 [package.dependencies]
@@ -493,14 +490,14 @@ testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packag
 
 [[package]]
 name = "importlib-resources"
-version = "5.10.2"
+version = "5.12.0"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_resources-5.10.2-py3-none-any.whl", hash = "sha256:7d543798b0beca10b6a01ac7cafda9f822c54db9e8376a6bf57e0cbd74d486b6"},
-    {file = "importlib_resources-5.10.2.tar.gz", hash = "sha256:e4a96c8cc0339647ff9a5e0550d9f276fc5a01ffa276012b58ec108cfd7b8484"},
+    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
+    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
 ]
 
 [package.dependencies]
@@ -896,11 +893,7 @@ files = [
 ]
 
 [package.dependencies]
-numpy = [
-    {version = ">=1.20.3", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
-    {version = ">=1.23.2", markers = "python_version >= \"3.11\""},
-]
+numpy = {version = ">=1.20.3", markers = "python_version < \"3.10\""}
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
@@ -1134,14 +1127,14 @@ yaml = ["PyYaml (>=5.2)"]
 
 [[package]]
 name = "python-semantic-release"
-version = "7.33.1"
+version = "7.33.2"
 description = "Automatic Semantic Versioning for Python projects"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "python-semantic-release-7.33.1.tar.gz", hash = "sha256:9d2e5681c2c296e0fc5d24088b59d7528c1c162920df29a4663d1131b5dfc97b"},
-    {file = "python_semantic_release-7.33.1-py3-none-any.whl", hash = "sha256:ad8bc816526d3d0d7a4cf4833cc57e655a28b34d6fa33b3d2786a07ae4e8a075"},
+    {file = "python-semantic-release-7.33.2.tar.gz", hash = "sha256:c23b4bb746e9ddbe1ba7497c48f7d81403e67a14ceb37928ef667c1fbee5e324"},
+    {file = "python_semantic_release-7.33.2-py3-none-any.whl", hash = "sha256:9e4990cc0a4dc37482ac5ec7fe6f70f71681228f68f0fa39370415701fdcf632"},
 ]
 
 [package.dependencies]
@@ -1593,14 +1586,14 @@ test = ["pytest (>=3.0.0)"]
 
 [[package]]
 name = "zipp"
-version = "3.13.0"
+version = "3.14.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.13.0-py3-none-any.whl", hash = "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"},
-    {file = "zipp-3.13.0.tar.gz", hash = "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6"},
+    {file = "zipp-3.14.0-py3-none-any.whl", hash = "sha256:188834565033387710d046e3fe96acfc9b5e86cbca7f39ff69cf21a4128198b7"},
+    {file = "zipp-3.14.0.tar.gz", hash = "sha256:9e5421e176ef5ab4c0ad896624e87a7b2f07aca746c9b2aa305952800cb8eecb"},
 ]
 
 [package.extras]
@@ -1609,5 +1602,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "f5843e25f90e5db8b8437e5b2ea5d16c4d3f29b24f5371d24c75ff926844689b"
+python-versions = "^3.8,<3.10"
+content-hash = "860d68b825cc270123b2ff82a4a97840423550617619b1a1ab49e78d96447a8f"


### PR DESCRIPTION
When encountering a contig not in the reference GTF:
Always annotate as `unannotated_reference` in the junctions file.
By default, exclude from the summary report.
With flag, call them `complete_novel` in the summary (but still `unannotated_reference` in the junctions file)

I labelled this as a "feat" which will bump us to v2.5.0. However this will change the output values, so I think it should be considered a breaking change that bumps us to v3? I'm not sure, what do you think @claymcleod ?