### PR TITLE
fix: -1 n-reads default for encoding. don't falsely imply random sampling

### DIFF
--- a/docs/subcommands/readlen.md
+++ b/docs/subcommands/readlen.md
@@ -6,7 +6,7 @@ The `readlen` subcommand can be used to compute the read length used during sequ
 
 At the time of writing, the algorithm used is roughly:
 
-1. Compute distribution of read lengths for the first `--n-samples` reads in a file.
+1. Compute distribution of read lengths for the first `--n-reads` reads in a file.
 2. Assuming read length in the file can only decrease from the actual read length (from adapter trimming or similar), the putative maximum read length is considered to be the highest detected read length.
 3. If the percentage of reads that are evidence for the putative maximum read length makes up at least `--majority-vote-cutoff`% of the reads, the putative read length is considered to be confirmed. If not, the consensus read length will be return as -1 (could not determine).
    * For example, if 100bp is the maximum read length detected and 85% percent of the reads support that claim, then we considered 100bp as the consensus read length. If only 30% of the reads indicated 100bp, the tool cannot report a consensus.

--- a/ngsderive/__main__.py
+++ b/ngsderive/__main__.py
@@ -67,10 +67,10 @@ def get_args():
     )
     readlen.add_argument(
         "-n",
-        "--n-samples",
+        "--n-reads",
         type=int,
-        help="How many reads to sample. Any n < 1 to parse whole file.",
-        default=1000000,
+        help="How many reads to analyze from the start of the file. Any n < 1 to parse whole file.",
+        default=-1,
     )
 
     instrument = subparsers.add_parser(
@@ -78,9 +78,9 @@ def get_args():
     )
     instrument.add_argument(
         "-n",
-        "--n-samples",
+        "--n-reads",
         type=int,
-        help="How many reads to sample. Any n < 1 to parse whole file.",
+        help="How many reads to analyze from the start of the file. Any n < 1 to parse whole file.",
         default=10000,
     )
 
@@ -149,9 +149,9 @@ def get_args():
     )
     encoding.add_argument(
         "-n",
-        "--n-samples",
+        "--n-reads",
         type=int,
-        help="How many reads to sample. Any n < 1 to parse whole file.",
+        help="How many reads to analyze from the start of the file. Any n < 1 to parse whole file.",
         default=1000000,
     )
 
@@ -280,14 +280,14 @@ def run():
         readlen.main(
             args.ngsfiles,
             outfile=args.outfile,
-            n_samples=args.n_samples,
+            n_reads=args.n_reads,
             majority_vote_cutoff=args.majority_vote_cutoff,
         )
     if args.subcommand == "instrument":
         instrument.main(
             args.ngsfiles,
             outfile=args.outfile,
-            n_samples=args.n_samples,
+            n_reads=args.n_reads,
         )
     if args.subcommand == "strandedness":
         max_iters = args.max_iterations_per_try
@@ -308,7 +308,7 @@ def run():
         encoding.main(
             args.ngsfiles,
             outfile=args.outfile,
-            n_samples=args.n_samples,
+            n_reads=args.n_reads,
         )
     if args.subcommand == "junction-annotation":
         junction_annotation.main(

--- a/ngsderive/commands/encoding.py
+++ b/ngsderive/commands/encoding.py
@@ -17,7 +17,7 @@ ILLUMINA_1_0_SET = set([i for i in range(26, 93)])
 ILLUMINA_1_3_SET = set([i for i in range(31, 93)])
 
 
-def main(ngsfiles, outfile=sys.stdout, n_samples=1000000):
+def main(ngsfiles, outfile, n_reads):
 
     writer = csv.DictWriter(
         outfile,
@@ -27,8 +27,8 @@ def main(ngsfiles, outfile=sys.stdout, n_samples=1000000):
     writer.writeheader()
     outfile.flush()
 
-    if n_samples < 1:
-        n_samples = None
+    if n_reads < 1:
+        n_reads = None
 
     for ngsfilepath in ngsfiles:
         try:
@@ -44,7 +44,7 @@ def main(ngsfiles, outfile=sys.stdout, n_samples=1000000):
             continue
 
         score_set = set()
-        for read in itertools.islice(ngsfile, n_samples):
+        for read in itertools.islice(ngsfile, n_reads):
             score_set.update(read["quality"])
 
         highest_ascii = str(max(score_set) + 33)

--- a/ngsderive/commands/instrument.py
+++ b/ngsderive/commands/instrument.py
@@ -195,7 +195,7 @@ def resolve_instrument(
         )
 
 
-def main(ngsfiles, outfile=sys.stdout, n_samples=10000):
+def main(ngsfiles, outfile, n_reads):
     writer = csv.DictWriter(
         outfile,
         fieldnames=["File", "Instrument", "Confidence", "Basis"],
@@ -204,8 +204,8 @@ def main(ngsfiles, outfile=sys.stdout, n_samples=10000):
     writer.writeheader()
     outfile.flush()
 
-    if n_samples < 1:
-        n_samples = None
+    if n_reads < 1:
+        n_reads = None
 
     for ngsfilepath in ngsfiles:
         try:
@@ -227,7 +227,7 @@ def main(ngsfiles, outfile=sys.stdout, n_samples=10000):
         malformed_read_names = False
 
         # accumulate instrument and flowcell IDs
-        for read in itertools.islice(ngsfile, n_samples):
+        for read in itertools.islice(ngsfile, n_reads):
             parts = read["query_name"].split(":")
             if len(parts) != 7:  # not Illumina format
                 malformed_read_names = True

--- a/ngsderive/commands/junction_annotation.py
+++ b/ngsderive/commands/junction_annotation.py
@@ -256,14 +256,14 @@ def annotate_junctions(
 def main(
     ngsfiles,
     gene_model_file,
-    outfile=sys.stdout,
-    min_intron=50,
-    min_mapq=30,
-    min_reads=2,
-    fuzzy_range=0,
-    consider_unannotated_references_novel=False,
-    junction_dir="./",
-    disable_junction_files=False,
+    outfile,
+    min_intron,
+    min_mapq,
+    min_reads,
+    fuzzy_range,
+    consider_unannotated_references_novel,
+    junction_dir,
+    disable_junction_files,
 ):
     logger.info("Arguments:")
     logger.info("  - Gene model file: {}".format(gene_model_file))

--- a/ngsderive/commands/readlen.py
+++ b/ngsderive/commands/readlen.py
@@ -12,9 +12,9 @@ logger = logging.getLogger("readlen")
 
 def main(
     ngsfiles,
-    outfile=sys.stdout,
-    n_samples=100000,
-    majority_vote_cutoff=0.7,
+    outfile,
+    n_reads,
+    majority_vote_cutoff,
 ):
 
     writer = csv.DictWriter(
@@ -25,8 +25,8 @@ def main(
     writer.writeheader()
     outfile.flush()
 
-    if n_samples < 1:
-        n_samples = None
+    if n_reads < 1:
+        n_reads = None
 
     for ngsfilepath in ngsfiles:
         read_lengths = defaultdict(int)
@@ -46,7 +46,7 @@ def main(
 
         # accumulate read lengths
         total_reads_sampled = 0
-        for read in itertools.islice(ngsfile, n_samples):
+        for read in itertools.islice(ngsfile, n_reads):
             total_reads_sampled += 1
             read_lengths[len(read["query"])] += 1
 

--- a/ngsderive/commands/strandedness.py
+++ b/ngsderive/commands/strandedness.py
@@ -10,7 +10,7 @@ from ..utils import NGSFile, NGSFileType, GFF
 logger = logging.getLogger("strandedness")
 
 
-def get_filtered_reads_from_region(samfile, gene, min_quality=30, apply_filters=True):
+def get_filtered_reads_from_region(samfile, gene, min_quality, apply_filters=True):
     for read in samfile.fetch(gene["seqname"], gene["start"], gene["end"]):
         if apply_filters and (
             read.is_qcfail
@@ -78,13 +78,13 @@ def get_predicted_strandedness(forward_evidence_pct, reverse_evidence_pct):
 def determine_strandedness(
     ngsfilepath,
     gff,
-    n_genes=100,
-    min_mapq=30,
-    minimum_reads_per_gene=10,
-    split_by_rg=False,
-    max_iterations_per_try=1000,
-    checked_genes=set(),
-    overall_evidence=defaultdict(lambda: defaultdict(int)),
+    n_genes,
+    min_mapq,
+    minimum_reads_per_gene,
+    split_by_rg,
+    max_iterations_per_try,
+    checked_genes,
+    overall_evidence,
 ):
     try:
         ngsfile = NGSFile(ngsfilepath)
@@ -294,14 +294,14 @@ def determine_strandedness(
 def main(
     ngsfiles,
     gene_model_file,
-    outfile=sys.stdout,
-    n_genes=100,
-    minimum_reads_per_gene=10,
-    only_protein_coding_genes=True,
-    min_mapq=30,
-    split_by_rg=False,
-    max_tries=3,
-    max_iterations_per_try=1000,
+    outfile,
+    n_genes,
+    minimum_reads_per_gene,
+    only_protein_coding_genes,
+    min_mapq,
+    split_by_rg,
+    max_tries,
+    max_iterations_per_try,
 ):
     logger.info("Arguments:")
     logger.info("  - Gene model file: {}".format(gene_model_file))


### PR DESCRIPTION
The `--n-samples` parameter and it's associated help text implied a random sample when in reality only the first `n` reads of the file were being processed. `--n-samples` has been renamed `--n-reads` and the help text makes it clear only the first `n` reads of the file are analyzed.

Any random sampling approach will have a similar hit on run-time as simply processing the whole file (both are O(n) where n=read count of the entire file. What's on `main` is O(k) where k=n-reads processed=default of 1million). A 2 pass random sampling algorithm was implemented and tested, a 1 pass algorithm was considered, but either would be too big a jump in run-time to justify releasing to production (going from the scale of seconds (regardless of file size) to minutes that scaled up linearly with file size).

(assuming a position sorted BAM*) random sampling should in theory be needless and overkill for the `encoding` and `instrument` subcommands. However me and David discovered a bias introduced by position sorted BAMs for the `readlen` command. A large number of BAMs were returning inconclusive read lengths, until random sampling or processing the entire BAM was tried. This makes biological sense. To put it simply, the reads mapping to the ends of chromosomes on or near the telomeres tend to be "junky" and are more likely to be trimmed below the original read length.
*for name sorted files the first `n` approach will obviously screw up the `instrument` results. Since `encoding` only cares about the upper and lower bound of PHRED scores, it's relatively free of any bias introduced by file sort method. Position sorted BAMs may have a higher portion of low PHRED reads at the beginning of the file (because of telomeres), but this would actually help the algorithm differentiate the various encoding schemes (i.e. the bias in this particular case leads to better results).

Instead of taking on the time consuming task of implementing a reservoir sampling method (efficient 1 pass normal distribution sampling), I decided the default for `readlen` should just be "process the entire file". The performance is on the same scale as a reservoir sampling method, but it took me a few seconds to implement instead of many hours.

The QC pipeline is the largest user of `ngsderive`, and it runs all subcommands on a position sorted BAM. IMO we should tailor the defaults to the people actually using the tool (AKA me 😅 ).
I'd consider updating `instrument` to default to processing the entire BAM under a similar theory that it is the proper setting for a name sorted BAM. But I'm not sure anyone is running `instrument` on name sorted BAMs, so that seems like a needless hit on typical run-time.

ETA: I also removed the redundant (and occasionally mismatched) default specifications. Multiple cases where the default specified in `argparse` was overwriting a different value defined in the subcommand function (which lead to a fair bit of confusion while developing/testing). Those value are _never_ used, and can only serve to introduce confusion when they get out-of-date with `argparse`.